### PR TITLE
Graph improvements

### DIFF
--- a/directed_test.go
+++ b/directed_test.go
@@ -190,6 +190,6 @@ func TestGraphQueries(t *testing.T) {
 		g.Associate(that, likes, g.Node(NodeKey("David")))
 	}
 
-	require.Equal(t, m, len(NodeSlice(g.To(g.Node("David"), likes).Nodes())))
+	require.Equal(t, m, len(NodeSlice(g.To(likes, g.Node("David")).Nodes())))
 	require.Equal(t, m*2, len(NodeSlice(g.From(g.Node("David"), likes).Nodes())))
 }

--- a/dot.go
+++ b/dot.go
@@ -6,6 +6,7 @@ import (
 	gonum "gonum.org/v1/gonum/graph"
 	"gonum.org/v1/gonum/graph/encoding"
 	"gonum.org/v1/gonum/graph/encoding/dot"
+	"gonum.org/v1/gonum/graph/simple"
 )
 
 type dotSubgraph struct {
@@ -146,7 +147,7 @@ func RenderDot(g Graph, options DotOptions) ([]byte, error) {
 
 	dg := &dotGraph{
 		DotOptions: options,
-		Directed:   xg.DirectedBuilder,
+		Directed:   simple.NewDirectedGraph(), //xg.DirectedBuilder,
 		xg:         xg,
 	}
 

--- a/graph_test.go
+++ b/graph_test.go
@@ -130,15 +130,15 @@ func TestAssociate(t *testing.T) {
 	require.Nil(t, g.Edge(C, shares, A), "Shares is not an association kind between A and B.")
 
 	require.Equal(t, 2, len(EdgeSlice(g.From(A, likes).Edges())))
-	require.Equal(t, 1, len(EdgeSlice(g.To(B, likes).Edges())))
-	require.Equal(t, "A", EdgeSlice(g.To(B, likes).Edges())[0].From().NodeKey())
-	require.Equal(t, "B", EdgeSlice(g.To(B, likes).Edges())[0].To().NodeKey())
-	require.Equal(t, 1, len(EdgeSlice(g.To(C, likes).Edges())))
-	require.Equal(t, "A", EdgeSlice(g.To(C, likes).Edges())[0].From().NodeKey())
-	require.Equal(t, "C", EdgeSlice(g.To(C, likes).Edges())[0].To().NodeKey())
+	require.Equal(t, 1, len(EdgeSlice(g.To(likes, B).Edges())))
+	require.Equal(t, "A", EdgeSlice(g.To(likes, B).Edges())[0].From().NodeKey())
+	require.Equal(t, "B", EdgeSlice(g.To(likes, B).Edges())[0].To().NodeKey())
+	require.Equal(t, 1, len(EdgeSlice(g.To(likes, C).Edges())))
+	require.Equal(t, "A", EdgeSlice(g.To(likes, C).Edges())[0].From().NodeKey())
+	require.Equal(t, "C", EdgeSlice(g.To(likes, C).Edges())[0].To().NodeKey())
 	require.Equal(t, 0, len(EdgeSlice(g.From(B, likes).Edges())))
 	require.Equal(t, 0, len(EdgeSlice(g.From(C, likes).Edges())))
-	require.Equal(t, 0, len(EdgeSlice(g.To(A, likes).Edges())), "D was not added")
+	require.Equal(t, 0, len(EdgeSlice(g.To(likes, A).Edges())), "D was not added")
 	require.Equal(t, 0, len(EdgeSlice(g.From(D, likes).Edges())), "D was not added")
 
 }

--- a/node.go
+++ b/node.go
@@ -39,14 +39,14 @@ func (n *node) Attributes() []encoding.Attribute {
 }
 
 type nodesOrEdges struct {
-	nodes func() Nodes
-	edges func() Edges
+	nodes func([]func(Node) bool) Nodes
+	edges func([]func(Edge) bool) Edges
 }
 
-func (q *nodesOrEdges) Nodes() Nodes {
-	return q.nodes()
+func (q *nodesOrEdges) Nodes(optional ...func(Node) bool) Nodes {
+	return q.nodes(optional)
 }
 
-func (q *nodesOrEdges) Edges() Edges {
-	return q.edges()
+func (q *nodesOrEdges) Edges(optional ...func(Edge) bool) Edges {
+	return q.edges(optional)
 }

--- a/types.go
+++ b/types.go
@@ -1,8 +1,11 @@
 package xgraph // import "github.com/orkestr8/xgraph"
 
 type NodeKey interface{}
-type Node interface {
+type NodeKeyer interface {
 	NodeKey() NodeKey
+}
+type Node interface {
+	NodeKeyer
 }
 
 type Contexter interface {
@@ -21,6 +24,9 @@ type Edge interface {
 }
 
 type Options struct {
+
+	// NodeIDOffset is the base to increment node id from.
+	NodeIDOffset int64
 }
 
 type GraphBuilder interface {
@@ -34,14 +40,14 @@ type Nodes <-chan Node
 type Edges <-chan Edge
 
 type NodesOrEdges interface {
-	Nodes() Nodes
-	Edges() Edges
+	Nodes(...func(Node) bool) Nodes
+	Edges(...func(Edge) bool) Edges
 }
 
 type Graph interface {
 	Node(NodeKey) Node
 	Edge(from Node, kind EdgeKind, to Node) Edge
-	To(Node, EdgeKind) NodesOrEdges
+	To(EdgeKind, Node) NodesOrEdges
 	From(Node, EdgeKind) NodesOrEdges
 }
 


### PR DESCRIPTION
+ Id generator instead of base directed graph
+ filtering when searching for nodes and edges
+ update the vpc test case to show usage of filtering in new api.

It's now possible to add nodes which, when having no edges to them, are part of the graph but now not visible in dot graphviz.  This is because only subgraphs (by edge type/ EdgeKind) are rendered in the dot file.

Signed-off-by: chungers <davidc616+github_chungers@gmail.com>