### PR TITLE
Refactoring node/edge rendering of dotfile; Decoding of dotfile

### DIFF
--- a/directed.go
+++ b/directed.go
@@ -26,7 +26,7 @@ type directed struct {
 	lock sync.RWMutex
 }
 
-func (d *directed) associate(fromNode, toNode *node, optionalContext ...interface{}) *edgeView {
+func (d *directed) associate(fromNode, toNode *node, optionalContext ...interface{}) *edge {
 	d.lock.Lock()
 	defer d.lock.Unlock()
 
@@ -38,16 +38,16 @@ func (d *directed) associate(fromNode, toNode *node, optionalContext ...interfac
 	}
 
 	ed := &edge{
-		Edge:    d.NewEdge(fromNode, toNode),
+		gonum:   d.NewEdge(fromNode, toNode),
 		kind:    d.kind,
 		to:      toNode.Node,
 		from:    fromNode.Node,
 		context: optionalContext,
 	}
-	d.edges[ed] = ed
-	d.SetEdge(ed)
+	d.edges[ed.gonum] = ed
+	d.SetEdge(ed.gonum)
 
-	return &edgeView{ed}
+	return ed //&edgeView{ed}
 }
 
 func scopeDirected(g Graph, kind EdgeKind, do func(*directed) error) error {

--- a/dot_test.go
+++ b/dot_test.go
@@ -145,12 +145,72 @@ func TestEncoderDotVpc(t *testing.T) {
 		NodeLabelers: map[Node]NodeLabeler{},
 	}
 
-	buff, err := RenderDot(g, dotOptions)
+	buff, err := EncodeDot(g, dotOptions)
 	require.NoError(t, err)
 	fmt.Println(string(buff))
 
 }
 
+func TestDecodeDot(t *testing.T) {
+
+	dot := `
+strict digraph V {
+  edge [
+    color=blue
+    kind = input
+  ];
+
+  // Node definitions.
+  x1
+  x2
+  x3
+  y1
+  y2
+  sumX [op=sum, label=sum];
+  sumY [
+        op=sum, label=sum,
+        shape=doublecircle,
+        service=remote_inference
+       ];
+  ratio [op=ratio];
+
+  // Edge definitions.
+  sumX -> ratio;
+  sumY -> ratio;
+  x1 -> sumX;
+  x2 -> sumX;
+  x3 -> sumX;
+  x3 -> sumY [context=0];
+  y1 -> sumY [context=1];
+  y2 -> sumY [context=2];
+}
+`
+	t.Log(dot)
+
+	g := Builder(Options{})
+
+	kind := EdgeKind(0)
+	err := DecodeDot([]byte(dot), g, kind)
+	require.NoError(t, err)
+
+	// Now Encode
+	dotOptions := DotOptions{
+		Name:      "V",
+		Indent:    "  ",
+		NodeShape: NodeShapeBox,
+		Edges: map[EdgeKind]string{
+			kind: "input",
+		},
+		EdgeColors: map[EdgeKind]EdgeColor{
+			kind: EdgeColorRed,
+		},
+		EdgeLabelers: map[Edge]EdgeLabeler{},
+		NodeLabelers: map[Node]NodeLabeler{},
+	}
+	view, err := EncodeDot(g, dotOptions)
+	require.NoError(t, err)
+	t.Log(string(view))
+}
 func TestEncodeDot(t *testing.T) {
 
 	likes := EdgeKind(1)
@@ -209,11 +269,11 @@ func TestEncodeDot(t *testing.T) {
 		return fmt.Sprintf("%v %v %v", e.From(), dotOptions.Edges[e.Kind()], e.To())
 	}
 
-	buff, err := RenderDot(g, dotOptions)
+	buff, err := EncodeDot(g, dotOptions)
 	require.NoError(t, err)
 	fmt.Println(string(buff))
 
 	dotOptions.EdgeLabelers = nil
-	_, err = RenderDot(g, dotOptions)
+	_, err = EncodeDot(g, dotOptions)
 	require.NoError(t, err)
 }

--- a/edge.go
+++ b/edge.go
@@ -1,10 +1,7 @@
 package xgraph // import "github.com/orkestr8/xgraph"
 
 import (
-	"strings"
-
 	gonum "gonum.org/v1/gonum/graph"
-	"gonum.org/v1/gonum/graph/encoding"
 )
 
 type edge struct {
@@ -13,8 +10,6 @@ type edge struct {
 	to      Node
 	kind    EdgeKind
 	context []interface{}
-
-	labeler EdgeLabeler
 }
 
 func (e *edge) To() Node {
@@ -31,31 +26,4 @@ func (e *edge) Context() []interface{} {
 
 func (e *edge) Kind() EdgeKind {
 	return e.kind
-}
-
-func (e *edge) label() string {
-	if e.labeler != nil {
-		return e.labeler(e)
-	}
-
-	labels := []string{}
-	for i := range e.context {
-
-		switch v := e.context[i].(type) {
-		case func(Edge) string:
-			labels = append(labels, v(e))
-		case EdgeLabeler:
-			labels = append(labels, v(e))
-		}
-
-	}
-	return strings.Join(labels, ",")
-}
-
-func (e *edge) Attributes() []encoding.Attribute {
-	attr := attributes{}
-	if l := e.label(); l != "" {
-		attr["label"] = l
-	}
-	return attr.Attributes()
 }

--- a/edge.go
+++ b/edge.go
@@ -8,7 +8,7 @@ import (
 )
 
 type edge struct {
-	gonum.Edge
+	gonum   gonum.Edge
 	from    Node
 	to      Node
 	kind    EdgeKind
@@ -17,9 +17,25 @@ type edge struct {
 	labeler EdgeLabeler
 }
 
+func (e *edge) To() Node {
+	return e.to
+}
+
+func (e *edge) From() Node {
+	return e.from
+}
+
+func (e *edge) Context() []interface{} {
+	return e.context
+}
+
+func (e *edge) Kind() EdgeKind {
+	return e.kind
+}
+
 func (e *edge) label() string {
 	if e.labeler != nil {
-		return e.labeler(&edgeView{e})
+		return e.labeler(e)
 	}
 
 	labels := []string{}
@@ -27,9 +43,9 @@ func (e *edge) label() string {
 
 		switch v := e.context[i].(type) {
 		case func(Edge) string:
-			labels = append(labels, v(&edgeView{e}))
+			labels = append(labels, v(e))
 		case EdgeLabeler:
-			labels = append(labels, v(&edgeView{e}))
+			labels = append(labels, v(e))
 		}
 
 	}
@@ -42,28 +58,4 @@ func (e *edge) Attributes() []encoding.Attribute {
 		attr["label"] = l
 	}
 	return attr.Attributes()
-}
-
-// edgeView is used to work around the problem that gonum.Edge.From() and xgraph.Edge.From() can't
-// be disambiguated by the compiler (different return types).  Also, we want to restrict the
-// properties exposed by separating the api implementation from the low-level implementations
-// like dot.Attributer.
-type edgeView struct {
-	*edge
-}
-
-func (e *edgeView) To() Node {
-	return e.to
-}
-
-func (e *edgeView) From() Node {
-	return e.from
-}
-
-func (e *edgeView) Context() []interface{} {
-	return e.context
-}
-
-func (e *edgeView) Kind() EdgeKind {
-	return e.kind
 }

--- a/edge_test.go
+++ b/edge_test.go
@@ -7,39 +7,49 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestEdgeLabel(t *testing.T) {
+func TestDotEdgeLabel(t *testing.T) {
 
-	var ed *edge
-	ed = &edge{
-		context: []interface{}{},
+	var ed *dotEdge
+
+	ed = &dotEdge{
+		edge: &edge{
+			context: []interface{}{},
+		},
 	}
+
 	require.Equal(t, "", ed.label())
 
-	ed = &edge{
-		context: []interface{}{
-			"foo", "bar",
+	ed = &dotEdge{
+		edge: &edge{
+			context: []interface{}{
+				"foo", "bar",
+			},
 		},
 	}
 	require.Equal(t, "", ed.label())
 
 	label := "my label"
-	ed = &edge{
-		context: []interface{}{
-			func(edge Edge) string {
-				return label
+	ed = &dotEdge{
+		edge: &edge{
+			context: []interface{}{
+				func(edge Edge) string {
+					return label
+				},
 			},
 		},
 	}
 	require.Equal(t, label, ed.label())
 
 	label2 := "my label2"
-	ed = &edge{
-		context: []interface{}{
-			func(edge Edge) string {
-				return label
-			},
-			func(edge Edge) string {
-				return label2
+	ed = &dotEdge{
+		edge: &edge{
+			context: []interface{}{
+				func(edge Edge) string {
+					return label
+				},
+				func(edge Edge) string {
+					return label2
+				},
 			},
 		},
 	}

--- a/graph.go
+++ b/graph.go
@@ -9,10 +9,9 @@ import (
 type graph struct {
 	Options
 
-	nextID    *nodeID
-	directed  map[EdgeKind]*directed
-	nodeKeys  map[interface{}]*node
-	edgeViews map[*edge]*edgeView
+	nextID   *nodeID
+	directed map[EdgeKind]*directed
+	nodeKeys map[interface{}]*node
 
 	lock sync.RWMutex
 }
@@ -32,11 +31,10 @@ func (n *nodeID) get() (v int64) {
 
 func newGraph(options Options) *graph {
 	return &graph{
-		nextID:    &nodeID{value: options.NodeIDOffset},
-		Options:   options,
-		nodeKeys:  map[interface{}]*node{},
-		directed:  map[EdgeKind]*directed{},
-		edgeViews: map[*edge]*edgeView{},
+		nextID:   &nodeID{value: options.NodeIDOffset},
+		Options:  options,
+		nodeKeys: map[interface{}]*node{},
+		directed: map[EdgeKind]*directed{},
 	}
 }
 
@@ -66,15 +64,6 @@ func (g *graph) xgraph(n gonum.Node, more ...gonum.Node) []Node {
 		}
 	}
 	return out
-}
-
-func (g *graph) setLabelers(l NodeLabeler) int {
-	count := 0
-	for _, n := range g.nodeKeys {
-		n.labeler = l
-		count++
-	}
-	return count
 }
 
 /*
@@ -134,25 +123,6 @@ func (g *graph) Associate(from Node, kind EdgeKind, to Node, optionalContext ...
 	return g.directedGraph(kind).associate(fromNode, toNode, optionalContext...), nil
 }
 
-func (g *graph) edgeViewGet(edge *edge) *edgeView {
-	g.lock.RLock()
-	defer g.lock.RUnlock()
-	return g.edgeViews[edge]
-}
-
-func (g *graph) edgeView(edge *edge) *edgeView {
-	v := g.edgeViewGet(edge)
-	if v != nil {
-		return v
-	}
-	g.lock.Lock()
-	g.lock.Unlock()
-
-	v = &edgeView{edge}
-	g.edgeViews[edge] = v
-	return v
-}
-
 func (g *graph) Edge(from Node, kind EdgeKind, to Node) Edge {
 	directed, has := g.directed[kind]
 	if !has {
@@ -163,8 +133,7 @@ func (g *graph) Edge(from Node, kind EdgeKind, to Node) Edge {
 	if args[0] == nil || args[1] == nil {
 		return nil
 	}
-
-	return g.edgeView(directed.edges[directed.Edge(args[0].ID(), args[1].ID())])
+	return directed.edges[directed.Edge(args[0].ID(), args[1].ID())]
 }
 
 func (g *graph) From(from Node, kind EdgeKind) NodesOrEdges {
@@ -270,12 +239,12 @@ func (g *graph) findEdges(kind EdgeKind, x Node, to bool, checks []func(Edge) bo
 				break
 			}
 
-			var eval *edgeView
+			var eval *edge
 
 			if to {
-				eval = g.edgeView(directed.edges[directed.Edge(result.Node().ID(), arg.ID())])
+				eval = directed.edges[directed.Edge(result.Node().ID(), arg.ID())]
 			} else {
-				eval = g.edgeView(directed.edges[directed.Edge(arg.ID(), result.Node().ID())])
+				eval = directed.edges[directed.Edge(arg.ID(), result.Node().ID())]
 			}
 
 			if len(checks) == 0 {

--- a/node.go
+++ b/node.go
@@ -2,15 +2,12 @@ package xgraph // import "github.com/orkestr8/xgraph"
 
 import (
 	"fmt"
-
-	"gonum.org/v1/gonum/graph/encoding"
 )
 
 type node struct {
 	Node
 	id int64 // gonum id
 
-	labeler NodeLabeler
 }
 
 func (n *node) ID() int64 {
@@ -19,23 +16,6 @@ func (n *node) ID() int64 {
 
 func (n *node) String() string {
 	return fmt.Sprintf("%v@%d", n.NodeKey(), n.id)
-}
-
-func (n *node) label() string {
-	if n.labeler != nil {
-		return n.labeler(n.Node)
-	}
-	return fmt.Sprintf("%v", n.NodeKey())
-}
-
-func (n *node) Attributes() []encoding.Attribute {
-	attr := attributes{}
-
-	if l := n.label(); l != "" {
-		attr["label"] = l
-	}
-
-	return attr.Attributes()
 }
 
 type nodesOrEdges struct {


### PR DESCRIPTION
+ Removed `labeler` fields from the `node` and `edge` structs and instead created `dotNode` and `dotEdge` structs as wrappers when rendering a graph in dot (GraphViz) format.
+ Implemented `gonum.Graph` interface to correctly return wrapped structs during encoding of dotfiles.
+ Implemented decoding of dotfiles as a way to construct a graph from input string buffer.