### PR TITLE
Flow Executor

### DIFF
--- a/flow/analyze_test.go
+++ b/flow/analyze_test.go
@@ -16,7 +16,7 @@ func TestAnalyze1(t *testing.T) {
 	require.NoError(t, err)
 
 	options := Options{
-		Logger: logger(1),
+		Logger: testlog{t},
 	}
 	g, err := analyze(ref, gg, deps, ordered, options)
 	require.NoError(t, err)

--- a/flow/compile_test.go
+++ b/flow/compile_test.go
@@ -1,73 +1,11 @@
 package flow // import "github.com/orkestr8/xgraph/flow"
 
 import (
-	"fmt"
 	"testing"
 
 	xg "github.com/orkestr8/xgraph"
 	"github.com/stretchr/testify/require"
 )
-
-type testlog struct {
-	*testing.T
-}
-
-func (s testlog) Log(context string, args ...interface{}) {
-	s.T.Log([]interface{}{"INFO", context, args}...)
-}
-
-func (s testlog) Warn(context string, args ...interface{}) {
-	s.T.Log([]interface{}{"WARN", context, args}...)
-}
-
-type benchlog struct {
-	*testing.B
-	log bool
-}
-
-func (s benchlog) Log(context string, args ...interface{}) {
-	if s.log {
-		s.B.Log([]interface{}{"INFO", context, args}...)
-	}
-}
-
-func (s benchlog) Warn(context string, args ...interface{}) {
-	if s.log {
-		s.B.Log([]interface{}{"WARN", context, args}...)
-	}
-}
-
-func testBuildGraph(input xg.EdgeKind) xg.Graph {
-
-	print := func(nodeKey interface{}) xg.OperatorFunc {
-		return func(args []interface{}) (interface{}, error) {
-			return fmt.Sprintf("%v(%v)", nodeKey, args), nil
-		}
-	}
-
-	// Ratio(Sum(x1, x2, x3), Sum(x3, y1, y2))
-	x1 := &nodeT{id: "x1", operator: print("x1")}
-	x2 := &nodeT{id: "x2", operator: print("x2")}
-	x3 := &nodeT{id: "x3", operator: print("x3")}
-	y1 := &nodeT{id: "y1", operator: print("y1")}
-	y2 := &nodeT{id: "y2", operator: print("y2")}
-	sumX := &nodeT{id: "sumX", operator: print("sumX")}
-	sumY := &nodeT{id: "sumY", operator: print("sumY")}
-	ratio := &nodeT{id: "ratio", operator: print("ratio")}
-
-	g := xg.Builder(xg.Options{})
-	g.Add(x1, x2, x3, y1, y2, sumX, sumY, ratio)
-
-	g.Associate(x1, input, sumX) // ordering comes from the nodeKey, lexicographically
-	g.Associate(x2, input, sumX)
-	g.Associate(x3, input, sumX)
-	g.Associate(y1, input, sumY, xg.Attribute{Key: "order", Value: 2})
-	g.Associate(y2, input, sumY, xg.Attribute{Key: "order", Value: 1})
-	g.Associate(x3, input, sumY, xg.Attribute{Key: "order", Value: 0})
-	g.Associate(sumX, input, ratio, xg.Attribute{Key: "order", Value: 0}) // positional arg index
-	g.Associate(sumY, input, ratio, xg.Attribute{Key: "order", Value: 1})
-	return g
-}
 
 func TestCompileExec(t *testing.T) {
 

--- a/flow/context.go
+++ b/flow/context.go
@@ -6,16 +6,10 @@ import (
 
 type contextKeyType int
 
-var (
-	nullFlowID = flowID(nil)
-)
-
 const (
 	flowIDContextKey contextKeyType = iota
 	loggerContextKey
-
-	// operatorContextKey
-	// nullFlowOperator = "__null__"
+	gatherChanContextKey
 )
 
 func setLogger(ctx context.Context, l Logger) context.Context {
@@ -26,25 +20,25 @@ func setFlowID(ctx context.Context, id flowID) context.Context {
 	return context.WithValue(ctx, flowIDContextKey, id)
 }
 
-// func setFlowOperator(ctx context.Context, op string) context.Context {
-// 	return context.WithValue(ctx, operatorContextKey, op)
-// }
+func setGatherChan(ctx context.Context, ch chan gather) context.Context {
+	return context.WithValue(ctx, gatherChanContextKey, ch)
+}
 
 func flowIDFrom(ctx context.Context) flowID {
 	v, is := ctx.Value(flowIDContextKey).(flowID)
 	if is {
 		return v
 	}
-	return nullFlowID
+	return nil
 }
 
-// func flowOperatorFrom(ctx context.Context) string {
-// 	v, is := ctx.Value(operatorContextKey).(string)
-// 	if is {
-// 		return v
-// 	}
-// 	return nullFlowOperator
-// }
+func gatherChanFrom(ctx context.Context) chan gather {
+	v, is := ctx.Value(gatherChanContextKey).(chan gather)
+	if is {
+		return v
+	}
+	return nil
+}
 
 func loggerFrom(ctx context.Context) Logger {
 	v, is := ctx.Value(loggerContextKey).(Logger)

--- a/flow/context.go
+++ b/flow/context.go
@@ -10,6 +10,7 @@ const (
 	flowIDContextKey contextKeyType = iota
 	loggerContextKey
 	gatherChanContextKey
+	awaitableContextKey
 )
 
 func setLogger(ctx context.Context, l Logger) context.Context {
@@ -24,6 +25,10 @@ func setGatherChan(ctx context.Context, ch chan gather) context.Context {
 	return context.WithValue(ctx, gatherChanContextKey, ch)
 }
 
+func setAwaitable(ctx context.Context, aw Awaitable) context.Context {
+	return context.WithValue(ctx, awaitableContextKey, aw)
+}
+
 func flowIDFrom(ctx context.Context) flowID {
 	v, is := ctx.Value(flowIDContextKey).(flowID)
 	if is {
@@ -34,6 +39,14 @@ func flowIDFrom(ctx context.Context) flowID {
 
 func gatherChanFrom(ctx context.Context) chan gather {
 	v, is := ctx.Value(gatherChanContextKey).(chan gather)
+	if is {
+		return v
+	}
+	return nil
+}
+
+func awaitableFrom(ctx context.Context) Awaitable {
+	v, is := ctx.Value(awaitableContextKey).(Awaitable)
 	if is {
 		return v
 	}

--- a/flow/context_test.go
+++ b/flow/context_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestContextFlowID(t *testing.T) {
 
-	require.Equal(t, nullFlowID, flowIDFrom(context.Background()))
+	require.Nil(t, flowIDFrom(context.Background()))
 
 	ctx := context.Background()
 	id := flowID(10000)

--- a/flow/flow.go
+++ b/flow/flow.go
@@ -4,7 +4,7 @@ import (
 	xg "github.com/orkestr8/xgraph"
 )
 
-func New(ref GraphRef, g xg.Graph, kind xg.EdgeKind, options Options) (Executor, error) {
+func NewExecutor(ref GraphRef, g xg.Graph, kind xg.EdgeKind, options Options) (Executor, error) {
 	ordered, err := xg.DirectedSort(g, kind)
 	if err != nil {
 		return nil, err

--- a/flow/flow.go
+++ b/flow/flow.go
@@ -4,6 +4,17 @@ import (
 	xg "github.com/orkestr8/xgraph"
 )
 
+func New(ref GraphRef, g xg.Graph, kind xg.EdgeKind, options Options) (Executor, error) {
+	ordered, err := xg.DirectedSort(g, kind)
+	if err != nil {
+		return nil, err
+	}
+	gg, err := analyze(ref, g, kind, ordered, options)
+	gg.run()
+	return gg, err
+
+}
+
 func NewFlowGraph(g xg.Graph, kind xg.EdgeKind) (*FlowGraph, error) {
 	fg := &FlowGraph{
 		Graph:      g,

--- a/flow/flow_test.go
+++ b/flow/flow_test.go
@@ -1,0 +1,123 @@
+package flow // import "github.com/orkestr8/xgraph/flow"
+
+import (
+	"context"
+	"testing"
+
+	xg "github.com/orkestr8/xgraph"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFlowNew(t *testing.T) {
+	ref := GraphRef("test")
+	kind := xg.EdgeKind(1)
+	gg := testBuildGraph(kind)
+	options := Options{
+		Logger: testlog{t},
+	}
+	executor, err := New(ref, gg, kind, options)
+	require.NoError(t, err)
+
+	require.NoError(t, executor.Close())
+}
+
+func TestFlowExecFull(t *testing.T) {
+	ref := GraphRef("test")
+	kind := xg.EdgeKind(1)
+	gg := testBuildGraph(kind)
+	options := Options{
+		Logger: testlog{t},
+	}
+	executor, err := New(ref, gg, kind, options)
+	require.NoError(t, err)
+
+	x1 := gg.Node(xg.NodeKey("x1"))
+	x2 := gg.Node(xg.NodeKey("x2"))
+	x3 := gg.Node(xg.NodeKey("x3"))
+	y1 := gg.Node(xg.NodeKey("y1"))
+	y2 := gg.Node(xg.NodeKey("y2"))
+	ratio := gg.Node(xg.NodeKey("ratio"))
+
+	ctx := context.Background()
+
+	ctx, future1, err := executor.Exec(ctx, map[xg.Node]interface{}{
+		x1: "X1",
+		x2: "X2",
+		x3: "X3",
+		y1: "Y1",
+		y2: "Y2",
+	})
+
+	ch1 := make(chan interface{})
+	go func() {
+		m := future1.Value().(map[xg.Node]Awaitable)
+		ch1 <- m[ratio].Value()
+		close(ch1)
+	}()
+
+	ch2 := make(chan interface{})
+	go func() {
+		m := future1.Value().(map[xg.Node]Awaitable)
+		ch2 <- m[ratio].Value()
+		close(ch2)
+	}()
+
+	exp := "ratio([sumX([X1 X2 X3]) sumY([X3 Y2 Y1])])"
+	require.Equal(t, exp, <-ch1)
+	require.Equal(t, exp, <-ch2)
+}
+
+func TestFlowExecPartialCalls(t *testing.T) {
+	ref := GraphRef("test")
+	kind := xg.EdgeKind(1)
+	gg := testBuildGraph(kind)
+	options := Options{
+		Logger: testlog{t},
+	}
+	executor, err := New(ref, gg, kind, options)
+	require.NoError(t, err)
+
+	x1 := gg.Node(xg.NodeKey("x1"))
+	x2 := gg.Node(xg.NodeKey("x2"))
+	x3 := gg.Node(xg.NodeKey("x3"))
+	y1 := gg.Node(xg.NodeKey("y1"))
+	y2 := gg.Node(xg.NodeKey("y2"))
+	ratio := gg.Node(xg.NodeKey("ratio"))
+
+	ctx := context.Background()
+
+	// note that each partial call gets a future
+	// which is used in separate goroutines to wait
+	// for the result.  We expect the futures to block
+	// the same and return the same results.
+	ctx, future1, err := executor.Exec(ctx, map[xg.Node]interface{}{
+		x1: "X1",
+		x2: "X2",
+		x3: "X3",
+	})
+	require.NoError(t, err)
+
+	ctx, future2, err := executor.Exec(ctx, map[xg.Node]interface{}{
+		y1: "Y1",
+		y2: "Y2",
+	})
+	require.NoError(t, err)
+
+	ch1 := make(chan interface{})
+	go func() {
+		m := future1.Value().(map[xg.Node]Awaitable)
+		ch1 <- m[ratio].Value()
+		close(ch1)
+	}()
+
+	ch2 := make(chan interface{})
+	go func() {
+		m := future2.Value().(map[xg.Node]Awaitable)
+		ch2 <- m[ratio].Value()
+		close(ch2)
+	}()
+
+	exp := "ratio([sumX([X1 X2 X3]) sumY([X3 Y2 Y1])])"
+	require.Equal(t, exp, <-ch1)
+	require.Equal(t, exp, <-ch2)
+}

--- a/flow/graph.go
+++ b/flow/graph.go
@@ -147,3 +147,21 @@ func (g *graph) Exec(ctx context.Context, args map[xg.Node]interface{}) (context
 
 	return ctx, aw, err
 }
+
+func (g *graph) ExecAwaitables(ctx context.Context, args map[xg.Node]Awaitable) (context.Context, Awaitable, error) {
+
+	ctx, ch, err := g.execFutures(ctx, args)
+	if err != nil {
+		return ctx, nil, err
+	}
+
+	aw := awaitableFrom(ctx)
+	if aw == nil {
+		aw = Async(ctx, func() (interface{}, error) {
+			return map[xg.Node]Awaitable(<-ch), nil
+		})
+		ctx = setAwaitable(ctx, aw)
+	}
+
+	return ctx, aw, err
+}

--- a/flow/graph_test.go
+++ b/flow/graph_test.go
@@ -42,7 +42,7 @@ func TestGraphExec(t *testing.T) {
 	y2 := gg.Node(xg.NodeKey("y2"))
 	ratio := gg.Node(xg.NodeKey("ratio"))
 
-	ctx, result, err := g.exec(context.Background(),
+	ctx, result, err := g.execValues(context.Background(),
 		map[xg.Node]interface{}{
 			x1: "X1",
 			x2: "X2",
@@ -83,7 +83,7 @@ func TestGraphExecPartialTimeout(t *testing.T) {
 	}
 
 	ctx, _ := context.WithTimeout(context.Background(), 1*time.Second)
-	ctx, result, err := g.exec(ctx, X)
+	ctx, result, err := g.execValues(ctx, X)
 	require.NoError(t, err)
 
 	select {
@@ -120,7 +120,7 @@ func TestGraphExecPartialLateComplete(t *testing.T) {
 
 	// No cancelation..  will block indefinitely.
 	ctx := context.Background()
-	ctx, result, err := g.exec(ctx, X)
+	ctx, result, err := g.execValues(ctx, X)
 	require.NoError(t, err)
 
 	done := make(chan interface{})
@@ -141,13 +141,13 @@ func TestGraphExecPartialLateComplete(t *testing.T) {
 	}()
 
 	// Send in the rest...
-	ctx, _, err = g.exec(ctx, map[xg.Node]interface{}{
+	ctx, _, err = g.execValues(ctx, map[xg.Node]interface{}{
 		y1: "Y1",
 	})
 	require.NoError(t, err)
 
 	// Send in the rest...
-	ctx, _, err = g.exec(ctx, map[xg.Node]interface{}{
+	ctx, _, err = g.execValues(ctx, map[xg.Node]interface{}{
 		y2: "Y2",
 	})
 	require.NoError(t, err)

--- a/flow/graph_test.go
+++ b/flow/graph_test.go
@@ -18,7 +18,7 @@ func testAnalyzeGraph(t *testing.T) (*graph, xg.Graph, xg.EdgeKind) {
 	require.NoError(t, err)
 
 	options := Options{
-		Logger: logger(1),
+		Logger: testlog{t},
 	}
 	g, err := analyze(ref, gg, deps, ordered, options)
 	require.NoError(t, err)

--- a/flow/node.go
+++ b/flow/node.go
@@ -144,6 +144,15 @@ loop:
 	}
 }
 
+func tryClose(logger Logger, c chan<- gather) {
+	defer func() {
+		if e := recover(); e != nil {
+			logger.Warn("recovered:", e)
+		}
+	}()
+	close(c)
+}
+
 func (node *node) scatter(ready chan interface{}) {
 	pending := map[flowID]gather{}
 
@@ -186,6 +195,7 @@ func (node *node) scatter(ready chan interface{}) {
 			// Send the gathered futures to callback without blocking
 			select {
 			case w.callback <- gathered:
+				tryClose(w.Logger, w.callback)
 			default:
 			}
 			continue

--- a/flow/node_test.go
+++ b/flow/node_test.go
@@ -39,7 +39,7 @@ func (n *nodeT) Attributes() map[string]interface{} {
 
 func TestNodeStartStop(t *testing.T) {
 	n := &node{
-		Logger: logger(1),
+		Logger: testlog{t},
 		Node:   &nodeT{id: "1"},
 	}
 
@@ -133,7 +133,7 @@ func TestNodeScatter(t *testing.T) {
 	u1 := &nodeT{id: "upstream1"}
 	u2 := &nodeT{id: "upstream2"}
 	n := &node{
-		Logger:    logger(1),
+		Logger:    testlog{t},
 		Node:      &nodeT{id: "operator"},
 		inputFrom: func() xg.NodeSlice { return []xg.Node{u1, u2} },
 		outbound:  []chan<- work{outbound1, outbound2},

--- a/flow/testing.go
+++ b/flow/testing.go
@@ -1,0 +1,69 @@
+package flow // import "github.com/orkestr8/xgraph/flow"
+
+import (
+	"fmt"
+	"testing"
+
+	xg "github.com/orkestr8/xgraph"
+)
+
+type testlog struct {
+	*testing.T
+}
+
+func (s testlog) Log(context string, args ...interface{}) {
+	s.T.Log([]interface{}{"INFO", context, args}...)
+}
+
+func (s testlog) Warn(context string, args ...interface{}) {
+	s.T.Log([]interface{}{"WARN", context, args}...)
+}
+
+type benchlog struct {
+	*testing.B
+	log bool
+}
+
+func (s benchlog) Log(context string, args ...interface{}) {
+	if s.log {
+		s.B.Log([]interface{}{"INFO", context, args}...)
+	}
+}
+
+func (s benchlog) Warn(context string, args ...interface{}) {
+	if s.log {
+		s.B.Log([]interface{}{"WARN", context, args}...)
+	}
+}
+
+func testBuildGraph(input xg.EdgeKind) xg.Graph {
+
+	print := func(nodeKey interface{}) xg.OperatorFunc {
+		return func(args []interface{}) (interface{}, error) {
+			return fmt.Sprintf("%v(%v)", nodeKey, args), nil
+		}
+	}
+
+	// Ratio(Sum(x1, x2, x3), Sum(x3, y1, y2))
+	x1 := &nodeT{id: "x1", operator: print("x1")}
+	x2 := &nodeT{id: "x2", operator: print("x2")}
+	x3 := &nodeT{id: "x3", operator: print("x3")}
+	y1 := &nodeT{id: "y1", operator: print("y1")}
+	y2 := &nodeT{id: "y2", operator: print("y2")}
+	sumX := &nodeT{id: "sumX", operator: print("sumX")}
+	sumY := &nodeT{id: "sumY", operator: print("sumY")}
+	ratio := &nodeT{id: "ratio", operator: print("ratio")}
+
+	g := xg.Builder(xg.Options{})
+	g.Add(x1, x2, x3, y1, y2, sumX, sumY, ratio)
+
+	g.Associate(x1, input, sumX) // ordering comes from the nodeKey, lexicographically
+	g.Associate(x2, input, sumX)
+	g.Associate(x3, input, sumX)
+	g.Associate(y1, input, sumY, xg.Attribute{Key: "order", Value: 2})
+	g.Associate(y2, input, sumY, xg.Attribute{Key: "order", Value: 1})
+	g.Associate(x3, input, sumY, xg.Attribute{Key: "order", Value: 0})
+	g.Associate(sumX, input, ratio, xg.Attribute{Key: "order", Value: 0}) // positional arg index
+	g.Associate(sumY, input, ratio, xg.Attribute{Key: "order", Value: 1})
+	return g
+}

--- a/flow/types.go
+++ b/flow/types.go
@@ -28,6 +28,7 @@ type Options struct {
 type Executor interface {
 	io.Closer
 	Exec(context.Context, map[xg.Node]interface{}) (context.Context, Awaitable, error)
+	ExecAwaitables(context.Context, map[xg.Node]Awaitable) (context.Context, Awaitable, error)
 }
 
 type FlowGraph struct {

--- a/flow/types.go
+++ b/flow/types.go
@@ -2,6 +2,7 @@ package flow // import "github.com/orkestr8/xgraph/flow"
 
 import (
 	"context"
+	"io"
 	"time"
 
 	xg "github.com/orkestr8/xgraph"
@@ -22,6 +23,11 @@ type Logger interface {
 
 type Options struct {
 	Logger
+}
+
+type Executor interface {
+	io.Closer
+	Exec(context.Context, map[xg.Node]interface{}) (context.Context, Awaitable, error)
 }
 
 type FlowGraph struct {


### PR DESCRIPTION
 + Added flow executor as the runtime engine that can execute a graph.
 + Added tests for cancelation; partial input with timeout, sequential invocations of partial inputs
 + Benchmarks for using Async vs Const 
```
goos: linux
goarch: amd64
pkg: github.com/orkestr8/xgraph/flow
BenchmarkExecWithConsts            10000            123954 ns/op
BenchmarkExecWithAwaitables        10000            143192 ns/op
PASS
```