### PR TITLE
Flow executor speedups and tests

### DIFF
--- a/flow/analyze.go
+++ b/flow/analyze.go
@@ -12,9 +12,9 @@ func OrderEdgesByEdgeAttributeOrderOrNodeKey(a, b xg.Edge) bool {
 	ca := a.Attributes()
 	cb := b.Attributes()
 	if len(ca) > 0 && len(cb) > 0 {
-		idx, ok := ca["order"].(int)
+		idx, ok := ca["arg"].(int)
 		if ok {
-			idx2, ok2 := cb["order"].(int)
+			idx2, ok2 := cb["arg"].(int)
 			if ok2 {
 				return idx < idx2
 			}
@@ -25,6 +25,10 @@ func OrderEdgesByEdgeAttributeOrderOrNodeKey(a, b xg.Edge) bool {
 
 func analyze(ref GraphRef, g xg.Graph, kind xg.EdgeKind, ordered xg.NodeSlice,
 	options Options) (*graph, error) {
+
+	if options.Logger == nil {
+		options.Logger = nologging{}
+	}
 
 	nodes := []*node{}
 	links := map[xg.Edge]chan work{}

--- a/flow/analyze_test.go
+++ b/flow/analyze_test.go
@@ -16,7 +16,7 @@ func TestAnalyze1(t *testing.T) {
 	require.NoError(t, err)
 
 	options := Options{
-		Logger: testlog{t},
+		Logger: nologging{},
 	}
 	g, err := analyze(ref, gg, deps, ordered, options)
 	require.NoError(t, err)

--- a/flow/compile.go
+++ b/flow/compile.go
@@ -11,9 +11,9 @@ func testOrderByContextIndex(a, b xg.Edge) bool {
 	ca := a.Attributes()
 	cb := b.Attributes()
 	if len(ca) > 0 && len(cb) > 0 {
-		idx, ok := ca["order"].(int)
+		idx, ok := ca["arg"].(int)
 		if ok {
-			idx2, ok2 := cb["order"].(int)
+			idx2, ok2 := cb["arg"].(int)
 			if ok2 {
 				return idx < idx2
 			}

--- a/flow/compile_test.go
+++ b/flow/compile_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCompileExec(t *testing.T) {
+func TestV1CompileExec(t *testing.T) {
 
 	input := xg.EdgeKind(1)
 	g := testBuildGraph(input)
@@ -15,13 +15,13 @@ func TestCompileExec(t *testing.T) {
 	flowGraph, err := NewFlowGraph(g, input)
 	require.NoError(t, err)
 
-	flowGraph.Logger = testlog{t}
+	flowGraph.Logger = nologging{}
 	flowGraph.EdgeLessFunc = testOrderByContextIndex
 
 	require.NoError(t, flowGraph.Compile())
 }
 
-func BenchmarkCompile(b *testing.B) {
+func BenchmarkV1Compile(b *testing.B) {
 
 	input := xg.EdgeKind(1)
 	g := testBuildGraph(input)
@@ -31,7 +31,7 @@ func BenchmarkCompile(b *testing.B) {
 		panic(err)
 	}
 
-	flowGraph.Logger = benchlog{B: b, log: false}
+	flowGraph.Logger = nologging{}
 	flowGraph.EdgeLessFunc = testOrderByContextIndex
 
 	for i := 0; i < b.N; i++ {

--- a/flow/constant.go
+++ b/flow/constant.go
@@ -1,0 +1,38 @@
+package flow // import "github.com/orkestr8/xgraph/flow"
+
+type constant struct {
+	value interface{}
+}
+
+func (c constant) Ch() <-chan interface{} {
+	ch := make(chan interface{})
+	close(ch)
+	return ch
+}
+
+func (c constant) Value() interface{} {
+	return c.value
+}
+
+func (c constant) Error() error {
+	if err, is := c.value.(error); is {
+		return err
+	}
+	return nil
+}
+
+func (c constant) Canceled() bool {
+	return false
+}
+
+func (c constant) DeadlineExceeded() bool {
+	return false
+}
+
+func (c constant) Yield(v interface{}, err error) {
+	return // no-op
+}
+
+func Const(v interface{}) Awaitable {
+	return &constant{value: v}
+}

--- a/flow/flow_test.go
+++ b/flow/flow_test.go
@@ -12,9 +12,7 @@ func TestFlowNew(t *testing.T) {
 	ref := GraphRef("test")
 	kind := xg.EdgeKind(1)
 	gg := testBuildGraph(kind)
-	options := Options{
-		Logger: testlog{t},
-	}
+	options := Options{}
 	executor, err := NewExecutor(ref, gg, kind, options)
 	require.NoError(t, err)
 
@@ -25,9 +23,7 @@ func TestFlowExecFull(t *testing.T) {
 	ref := GraphRef("test")
 	kind := xg.EdgeKind(1)
 	gg := testBuildGraph(kind)
-	options := Options{
-		Logger: testlog{t},
-	}
+	options := Options{}
 	executor, err := NewExecutor(ref, gg, kind, options)
 	require.NoError(t, err)
 
@@ -71,9 +67,7 @@ func TestFlowExecPartialCalls(t *testing.T) {
 	ref := GraphRef("test")
 	kind := xg.EdgeKind(1)
 	gg := testBuildGraph(kind)
-	options := Options{
-		Logger: testlog{t},
-	}
+	options := Options{}
 	executor, err := NewExecutor(ref, gg, kind, options)
 	require.NoError(t, err)
 
@@ -122,14 +116,27 @@ func TestFlowExecPartialCalls(t *testing.T) {
 	require.Equal(t, exp, <-ch2)
 }
 
+func BenchmarkCompile(b *testing.B) {
+
+	for i := 0; i < b.N; i++ {
+
+		ref := GraphRef("test")
+		kind := xg.EdgeKind(1)
+		gg := testBuildGraph(kind)
+		options := Options{}
+
+		executor, err := NewExecutor(ref, gg, kind, options)
+		require.NoError(b, err)
+		require.NoError(b, executor.Close())
+	}
+}
+
 func BenchmarkExecWithConsts(b *testing.B) {
 
 	ref := GraphRef("test")
 	kind := xg.EdgeKind(1)
 	gg := testBuildGraph(kind)
-	options := Options{
-		Logger: benchlog{B: b, log: false},
-	}
+	options := Options{}
 
 	executor, err := NewExecutor(ref, gg, kind, options)
 	require.NoError(b, err)
@@ -165,9 +172,7 @@ func BenchmarkExecWithAwaitables(b *testing.B) {
 	ref := GraphRef("test")
 	kind := xg.EdgeKind(1)
 	gg := testBuildGraph(kind)
-	options := Options{
-		Logger: benchlog{B: b, log: false},
-	}
+	options := Options{}
 
 	executor, err := NewExecutor(ref, gg, kind, options)
 	require.NoError(b, err)

--- a/flow/future.go
+++ b/flow/future.go
@@ -20,39 +20,6 @@ type Future interface {
 
 type Do func() (interface{}, error)
 
-type constant struct {
-	value interface{}
-}
-
-func (c constant) Ch() <-chan interface{} {
-	ch := make(chan interface{})
-	close(ch)
-	return ch
-}
-
-func (c constant) Value() interface{} {
-	return c.value
-}
-
-func (c constant) Error() error {
-	if err, is := c.value.(error); is {
-		return err
-	}
-	return nil
-}
-
-func (c constant) Canceled() bool {
-	return false
-}
-
-func (c constant) DeadlineExceeded() bool {
-	return false
-}
-
-func (c constant) Yield(v interface{}, err error) {
-	return // no-op
-}
-
 type future struct {
 	sync.WaitGroup
 	sync.RWMutex
@@ -143,8 +110,4 @@ func Async(ctx context.Context, do Do) Awaitable {
 	f := newFuture(do)
 	f.doAsync(ctx)
 	return f
-}
-
-func Const(v interface{}) Awaitable {
-	return &constant{value: v}
 }

--- a/flow/gather_test.go
+++ b/flow/gather_test.go
@@ -105,7 +105,7 @@ func TestWaitForNormal(t *testing.T) {
 
 	result := make(chan []interface{})
 	go func() {
-		args, err := waitFor(ctx, f)
+		args, err := waitFor(f)
 		result <- []interface{}{args, err}
 	}()
 
@@ -138,7 +138,7 @@ func TestWaitForContextCancel(t *testing.T) {
 	done := make(chan interface{})
 	go func() {
 		defer close(done)
-		args, err := waitFor(ctx, f)
+		args, err := waitFor(f)
 		require.Error(t, err)
 		require.Nil(t, args)
 	}()
@@ -174,7 +174,7 @@ func TestWaitForContextAsyncError(t *testing.T) {
 	done := make(chan interface{})
 	go func() {
 		defer close(done)
-		args, err := waitFor(ctx, f)
+		args, err := waitFor(f)
 		require.Error(t, err)
 		require.Equal(t, verr, err)
 		require.Nil(t, args)
@@ -212,7 +212,7 @@ func TestWaitForContextTimeout(t *testing.T) {
 	done := make(chan interface{})
 	go func() {
 		defer close(done)
-		args, err := waitFor(ctx, f)
+		args, err := waitFor(f)
 		require.Error(t, err)
 		require.Nil(t, args)
 	}()

--- a/flow/graph_test.go
+++ b/flow/graph_test.go
@@ -17,9 +17,7 @@ func testAnalyzeGraph(t *testing.T) (*graph, xg.Graph, xg.EdgeKind) {
 	ordered, err := xg.DirectedSort(gg, deps)
 	require.NoError(t, err)
 
-	options := Options{
-		Logger: testlog{t},
-	}
+	options := Options{}
 	g, err := analyze(ref, gg, deps, ordered, options)
 	require.NoError(t, err)
 	return g, gg, deps

--- a/flow/inline.go
+++ b/flow/inline.go
@@ -1,0 +1,70 @@
+package flow // import "github.com/orkestr8/xgraph/flow"
+
+import (
+	"sync"
+)
+
+type memoized struct {
+	value interface{}
+	err   error
+}
+
+type inline struct {
+	op   func() (interface{}, error)
+	memo *memoized
+	lock sync.RWMutex
+}
+
+func (c inline) Ch() <-chan interface{} {
+	ch := make(chan interface{})
+	close(ch)
+	return ch
+}
+
+func (c *inline) memoized() *memoized {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	return c.memo
+}
+
+func (c *inline) memoize(v interface{}, err error) *memoized {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.memo = &memoized{
+		value: v,
+		err:   err,
+	}
+	return c.memo
+}
+
+func (c *inline) Value() interface{} {
+	mem := c.memoized()
+	if mem != nil {
+		return mem.value
+	}
+	return c.memoize(c.op()).value
+}
+
+func (c *inline) Error() error {
+	mem := c.memoized()
+	if mem != nil {
+		return mem.err
+	}
+	return c.memoize(c.op()).err
+}
+
+func (c inline) Canceled() bool {
+	return false
+}
+
+func (c inline) DeadlineExceeded() bool {
+	return false
+}
+
+func (c inline) Yield(v interface{}, err error) {
+	return // no-op
+}
+
+func Inline(f func() (interface{}, error)) Awaitable {
+	return &inline{op: f}
+}

--- a/flow/logger.go
+++ b/flow/logger.go
@@ -4,6 +4,14 @@ import (
 	"fmt"
 )
 
+type nologger struct{}
+
+func (l nologger) Log(m string, args ...interface{}) {
+}
+
+func (l nologger) Warn(m string, args ...interface{}) {
+}
+
 type logger int
 
 func (l logger) Log(m string, args ...interface{}) {

--- a/flow/logger.go
+++ b/flow/logger.go
@@ -4,12 +4,12 @@ import (
 	"fmt"
 )
 
-type nologger struct{}
+type nologging struct{}
 
-func (l nologger) Log(m string, args ...interface{}) {
+func (l nologging) Log(m string, args ...interface{}) {
 }
 
-func (l nologger) Warn(m string, args ...interface{}) {
+func (l nologging) Warn(m string, args ...interface{}) {
 }
 
 type logger int

--- a/flow/node.go
+++ b/flow/node.go
@@ -233,7 +233,7 @@ func (node *node) applyAsync(ctx context.Context, m gather) Awaitable {
 		}
 
 		// futures and inputFrom are 1:1, so args and inputFrom are 1:1
-		args, err := waitFor(ctx, futures)
+		args, err := waitFor(futures)
 		if err != nil {
 			return nil, err
 		}

--- a/flow/node_test.go
+++ b/flow/node_test.go
@@ -39,7 +39,7 @@ func (n *nodeT) Attributes() map[string]interface{} {
 
 func TestNodeStartStop(t *testing.T) {
 	n := &node{
-		Logger: testlog{t},
+		Logger: logger(0),
 		Node:   &nodeT{id: "1"},
 	}
 
@@ -133,7 +133,7 @@ func TestNodeScatter(t *testing.T) {
 	u1 := &nodeT{id: "upstream1"}
 	u2 := &nodeT{id: "upstream2"}
 	n := &node{
-		Logger:    testlog{t},
+		Logger:    logger(1),
 		Node:      &nodeT{id: "operator"},
 		inputFrom: func() xg.NodeSlice { return []xg.Node{u1, u2} },
 		outbound:  []chan<- work{outbound1, outbound2},

--- a/flow/run_test.go
+++ b/flow/run_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 // TODO - This one has a race.  Turn on go test -v -race
-func _TestRun(t *testing.T) {
+func TestV1Run(t *testing.T) {
 
 	input := xg.EdgeKind(1)
 	g := testBuildGraph(input)
@@ -17,7 +17,7 @@ func _TestRun(t *testing.T) {
 	flowGraph, err := NewFlowGraph(g, input)
 	require.NoError(t, err)
 
-	flowGraph.Logger = testlog{t}
+	flowGraph.Logger = nologging{}
 	flowGraph.EdgeLessFunc = testOrderByContextIndex
 
 	require.NoError(t, flowGraph.Compile())
@@ -39,7 +39,7 @@ func _TestRun(t *testing.T) {
 	require.Equal(t, "ratio([sumX([x1([x1v]) x2([x2v]) x3([x3v])]) sumY([x3([x3v]) y2([y2v]) y1([y1v])])])", dag.Value())
 }
 
-func BenchmarkCompileRun(b *testing.B) {
+func BenchmarkV1Run(b *testing.B) {
 	input := xg.EdgeKind(1)
 	g := testBuildGraph(input)
 
@@ -48,7 +48,7 @@ func BenchmarkCompileRun(b *testing.B) {
 		panic(err)
 	}
 
-	flowGraph.Logger = benchlog{B: b, log: false}
+	flowGraph.Logger = nologging{}
 	flowGraph.EdgeLessFunc = testOrderByContextIndex
 
 	err = flowGraph.Compile()

--- a/flow/testing.go
+++ b/flow/testing.go
@@ -7,16 +7,28 @@ import (
 	xg "github.com/orkestr8/xgraph"
 )
 
+const (
+	// On slower machines testing.T.Log() fails when `go test -race`.
+	useTestingLog = true
+)
+
 type testlog struct {
 	*testing.T
 }
 
 func (s testlog) Log(context string, args ...interface{}) {
-	s.T.Log([]interface{}{"INFO", context, args}...)
+	if useTestingLog {
+		s.T.Log([]interface{}{"INFO", context, args}...)
+		return
+	}
+	fmt.Println([]interface{}{"INFO", context, args}...)
 }
 
 func (s testlog) Warn(context string, args ...interface{}) {
-	s.T.Log([]interface{}{"WARN", context, args}...)
+	if useTestingLog {
+		s.T.Log([]interface{}{"WARN", context, args}...)
+	}
+	fmt.Println([]interface{}{"WARN", context, args}...)
 }
 
 type benchlog struct {

--- a/flow/testing.go
+++ b/flow/testing.go
@@ -2,51 +2,9 @@ package flow // import "github.com/orkestr8/xgraph/flow"
 
 import (
 	"fmt"
-	"testing"
 
 	xg "github.com/orkestr8/xgraph"
 )
-
-const (
-	// On slower machines testing.T.Log() fails when `go test -race`.
-	useTestingLog = true
-)
-
-type testlog struct {
-	*testing.T
-}
-
-func (s testlog) Log(context string, args ...interface{}) {
-	if useTestingLog {
-		s.T.Log([]interface{}{"INFO", context, args}...)
-		return
-	}
-	fmt.Println([]interface{}{"INFO", context, args}...)
-}
-
-func (s testlog) Warn(context string, args ...interface{}) {
-	if useTestingLog {
-		s.T.Log([]interface{}{"WARN", context, args}...)
-	}
-	fmt.Println([]interface{}{"WARN", context, args}...)
-}
-
-type benchlog struct {
-	*testing.B
-	log bool
-}
-
-func (s benchlog) Log(context string, args ...interface{}) {
-	if s.log {
-		s.B.Log([]interface{}{"INFO", context, args}...)
-	}
-}
-
-func (s benchlog) Warn(context string, args ...interface{}) {
-	if s.log {
-		s.B.Log([]interface{}{"WARN", context, args}...)
-	}
-}
 
 func testBuildGraph(input xg.EdgeKind) xg.Graph {
 
@@ -72,10 +30,10 @@ func testBuildGraph(input xg.EdgeKind) xg.Graph {
 	g.Associate(x1, input, sumX) // ordering comes from the nodeKey, lexicographically
 	g.Associate(x2, input, sumX)
 	g.Associate(x3, input, sumX)
-	g.Associate(y1, input, sumY, xg.Attribute{Key: "order", Value: 2})
-	g.Associate(y2, input, sumY, xg.Attribute{Key: "order", Value: 1})
-	g.Associate(x3, input, sumY, xg.Attribute{Key: "order", Value: 0})
-	g.Associate(sumX, input, ratio, xg.Attribute{Key: "order", Value: 0}) // positional arg index
-	g.Associate(sumY, input, ratio, xg.Attribute{Key: "order", Value: 1})
+	g.Associate(y1, input, sumY, xg.Attribute{Key: "arg", Value: 2})
+	g.Associate(y2, input, sumY, xg.Attribute{Key: "arg", Value: 1})
+	g.Associate(x3, input, sumY, xg.Attribute{Key: "arg", Value: 0})
+	g.Associate(sumX, input, ratio, xg.Attribute{Key: "arg", Value: 0}) // positional arg index
+	g.Associate(sumY, input, ratio, xg.Attribute{Key: "arg", Value: 1})
 	return g
 }


### PR DESCRIPTION
+ Improve performance in V2 flow implementation by removing extra set of `SelectCase` when waiting for all input arguments to be evaluated and changing it to a simple loop.  This is because the futures themselves can be canceled and will either complete or abort during the loop evaluation where each future is sequentially tested.

Before
```
GOMAXPROCS=1 go test -bench=Benchmark .
INFO node.scatter node operator
INFO All input received node operator id 100 input map[upstream1:{0xc0004a8720 <nil> 0xc000014088 100 0xc000177380 <nil>} upstream2:{0xc0004a8780 <nil> 0xc000014088 100 0xc0001773b0 <nil>}]
goos: linux
goarch: amd64
pkg: github.com/orkestr8/xgraph/flow
BenchmarkV1Compile                 10000            235004 ns/op
BenchmarkCompile                   10000            329725 ns/op
BenchmarkExecWithConsts            10000            165003 ns/op
BenchmarkExecWithAwaitables        10000            194883 ns/op
BenchmarkV1Run                     10000            164569 ns/op
PASS
```

After
```
GOMAXPROCS=1 go test -bench=Benchmark .
INFO node.scatter node operator
INFO All input received node operator id 100 input map[upstream1:{0xc0003b7f80 <nil> 0xc000014088 100 0xc00011f890 <nil>} upstream2:{0xc0003c0000 <nil> 0xc000014088 100 0xc00011f9b0 <nil>}]
goos: linux
goarch: amd64
pkg: github.com/orkestr8/xgraph/flow
BenchmarkV1Compile                 10000            242276 ns/op
BenchmarkCompile                   10000            345767 ns/op
BenchmarkExecWithConsts            10000            121751 ns/op
BenchmarkExecWithAwaitables        10000            135341 ns/op
BenchmarkV1Run                     10000            166461 ns/op
PASS
```
  + Renamed Edge attribute `order` to `arg` to better indicate the attribute is for setting the index of argv to the operator.
  + Renamed tests to indicate version.  